### PR TITLE
Allow flashing all devices through a single topic

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -172,6 +172,7 @@ void BootNormal::loop() {
 
 void BootNormal::_prefixMqttTopic() {
   strcpy(_mqttTopic.get(), Interface::get().getConfig().get().mqtt.baseTopic);
+  strcat(_mqttTopic.get(), "/");
   strcat(_mqttTopic.get(), Interface::get().getConfig().get().deviceId);
 }
 

--- a/src/Homie/Boot/BootNormal.hpp
+++ b/src/Homie/Boot/BootNormal.hpp
@@ -98,6 +98,8 @@ class BootNormal : public Boot {
   void _onMqttPublish(uint16_t id);
   void _prefixMqttTopic();
   char* _prefixMqttTopic(PGM_P topic);
+  void _prefixMqttTopicForFlash();
+  char* _prefixMqttTopicForFlash(PGM_P topic);
   bool _publishOtaStatus(int status, const char* info = nullptr);
   void _endOtaUpdate(bool success, uint8_t update_error = UPDATE_ERROR_OK);
 

--- a/src/Homie/Boot/BootNormal.hpp
+++ b/src/Homie/Boot/BootNormal.hpp
@@ -71,6 +71,7 @@ class BootNormal : public Boot {
   bool _mqttDisconnectNotified;
   bool _otaOngoing;
   bool _flaggedForReboot;
+  bool _halfwayToFinish;
   uint16_t _mqttOfflineMessageId;
   char _fwChecksum[32 + 1];
   bool _otaIsBase64;
@@ -78,6 +79,7 @@ class BootNormal : public Boot {
   size_t _otaBase64Pads;
   size_t _otaSizeTotal;
   size_t _otaSizeDone;
+  size_t _otaSizeHalfTotal;
 
   std::unique_ptr<char[]> _mqttTopic;
 


### PR DESCRIPTION
This changes the topic the devices subscribe to for flashing over the air to a single topic that does not depend on the id of the device